### PR TITLE
Use headless version of OpenCV

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,8 @@ setup(
     author_email = 'clement.playout@polymtl.ca',
     download_url = 'https://github.com/ClementPla/NNTools/archive/refs/tags/v0.1.0.tar.gz',
     keywords = ['PyTorch', 'Neural Network', 'CNN', 'deep learning', 'training', 'dataset', 'image', 'configuration'],
-    author_email = 'clement.playout@polymtl.ca',
     install_requires = [
-        'torch', 'numpy','matplotlib','tqdm','pyyaml','pandas', 'torchvision', 'opencv-python',
+        'torch', 'numpy','matplotlib','tqdm','pyyaml','pandas', 'torchvision', 'opencv-python-headless',
         'segmentation_models_pytorch', 'bokeh'],
     description='Light library built to facilitate the training of neural network with Pytorch. '
 )


### PR DESCRIPTION
The full package `opencv-python` includes GUI functionalities that are not required in NNTools. Those functionalities need several dependencies that may not be installed, most notably in common Docker images

For example, using `python:3.9-slim`, `opencv-python` raises an `ImportError`
```bash
$ docker run -it python:3.9-slim bash -c "pip -q install opencv-python; python -c 'import cv2'"
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/cv2/__init__.py", line 181, in <module>
    bootstrap()
  File "/usr/local/lib/python3.9/site-packages/cv2/__init__.py", line 153, in bootstrap
    native_module = importlib.import_module("cv2")
  File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
ImportError: libGL.so.1: cannot open shared object file: No such file or directory
```
whereas `opencv-python-headless` is fine.
```bash
$ docker run -it python:3.9-slim bash -c "pip -q install opencv-python-headless; python -c 'import cv2'"
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
```

This is already what [Albumentations does](https://github.com/albumentations-team/albumentations/blob/master/setup.py), installing `opencv-python-headless` unless some other version is already installed.