### PR TITLE
Use `Literal` instead of `Union` type hint

### DIFF
--- a/src/nntools/dataset/abstract_image_dataset.py
+++ b/src/nntools/dataset/abstract_image_dataset.py
@@ -45,7 +45,7 @@ class AbstractImageDataset(Dataset, ABC):
     extract_image_id_function: Callable[[str], str] = identity
     recursive_loading: bool = True
     use_cache: bool = False
-    cache_option: Union[NNOpt.CACHE_DISK, NNOpt.CACHE_MEMORY] = field(default=NNOpt.CACHE_DISK, converter=NNOpt)
+    cache_option: Literal[NNOpt.CACHE_DISK, NNOpt.CACHE_MEMORY] = field(default=NNOpt.CACHE_DISK, converter=NNOpt)
     @cache_option.validator
     def _cache_option_validator(self, attribute, value):
         if self.use_cache and value is None:


### PR DESCRIPTION
Using a `Union` to type hint "one of these enum values" throws an error when importing `fundus_data_toolkit.datasets.classification` with Python 3.10:
```
TypeError: Union[arg, ...]: each arg must be a type. Got <NNOpt.CACHE_DISK: 'disk'>.
```

The issue seems to go away with Python 3.11, but I'm not quite sure why.